### PR TITLE
Fix Function.bind to accept falsy values

### DIFF
--- a/es5.js
+++ b/es5.js
@@ -138,12 +138,15 @@ if (!Function.prototype.bind) {
   Function.prototype.bind = function (o) {
     if (typeof this !== 'function') { throw TypeError("Bind must be called on a function"); }
     var slice = [].slice,
-        args = slice.call(arguments, 1),
+        length = arguments.length,
+        args = (arguments.length > 1) ? slice.call(arguments, 1) : [],
         self = this,
         bound = function () {
-          return self.apply(this instanceof nop ? this : (o || {}),
+          return self.apply(this instanceof nop ? this : o,
                             args.concat(slice.call(arguments)));
         };
+    
+    o = (length > 0) ? 0 : {};
 
     /** @constructor */
     function nop() {}


### PR DESCRIPTION
This allows proper binding of any falsy value, such as `null`, `false`, `0` etc.

This avoids bugs such as:

``` javascript
function oneUp() {
  return this + 1;
}
var one = oneUp.bind(0); // Is currently converted into {} since 0 is falsy
one() // Should return 1 but the polyfill currently returns "[object Object]1"
```
