### PR TITLE
Use `key` for example in keyboard.md

### DIFF
--- a/keyboard.md
+++ b/keyboard.md
@@ -31,7 +31,7 @@ properties.
 ```js
 div.onkeydown = function(e) {
   identifyKey(e); // for IE7-
-  switch (e.code) {
+  switch (e.key) {
     case 'ArrowLeft': map.scroll(-10, 0); break;
     case 'ArrowRight': map.scroll(10, 0); break;
     case 'ArrowUp': map.scroll(0, -10); break;


### PR DESCRIPTION
Per [D3E 6.2.2][1],`key` remaps with the keyboard layout, `code` doesn't. If the user is using soft-arrow keys (ie. a function mode on a mini-keyboard that doesn't have dedicated arrow keys), the same arrow-key behaviors should apply.

[1]: https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#relationship-between-key-code