### PR TITLE
Check each event, not the prototype, for location

### DIFF
--- a/keyboard.js
+++ b/keyboard.js
@@ -603,14 +603,12 @@
 
   var codeTable = remap(keyCodeToInfoTable, 'code');
 
-  var nativeLocation = 'KeyboardEvent' in global && 'location' in global.KeyboardEvent.prototype;
-
   function keyInfoForEvent(event) {
     var keyCode = 'keyCode' in event ? event.keyCode : 'which' in event ? event.which : 0;
 
     var keyInfo = (function(){
-      if (nativeLocation || 'keyLocation' in event) {
-        var location = nativeLocation ? event.location : event.keyLocation;
+      if ('location' in event || 'keyLocation' in event) {
+        var location = 'location' in event ? event.location : event.keyLocation;
         if (location && keyCode in locationTable[location]) {
           return locationTable[location][keyCode];
         }


### PR DESCRIPTION
Chrome doesn't have a 'location' property on the prototype, but it does have a 'location' property on events. Defining its presence based on the prototype causes the previous code to use 'keyLocation', which prompts the warning `'KeyboardEvent.keyLocation' is deprecated. Please use 'KeyboardEvent.location' instead.`