### PR TITLE
Tolerate presence of defineProperty polyfill

### DIFF
--- a/url.js
+++ b/url.js
@@ -76,9 +76,12 @@
     var instance = URLUtils(url || '');
 
     // Detect for ES5 getter/setter support
-    var ES5_GET_SET = (Object.defineProperties && (function () {
-      var o = {}; Object.defineProperties(o, { p: { 'get': function () { return true; } } }); return o.p;
-    }()));
+    var ES5_GET_SET = false;
+    try {
+      ES5_GET_SET = (Object.defineProperties && (function () {
+        var o = {}; Object.defineProperties(o, { p: { 'get': function () { return true; } } }); return o.p;
+      }()));
+    } catch (e) {};
 
     var self = ES5_GET_SET ? this : document.createElement('a');
 

--- a/url.js
+++ b/url.js
@@ -76,12 +76,17 @@
     var instance = URLUtils(url || '');
 
     // Detect for ES5 getter/setter support
-    var ES5_GET_SET = false;
-    try {
-      ES5_GET_SET = (Object.defineProperties && (function () {
-        var o = {}; Object.defineProperties(o, { p: { 'get': function () { return true; } } }); return o.p;
-      }()));
-    } catch (e) {};
+    // (an Object.defineProperties polyfill that doesn't support getters/setters may throw)
+    var ES5_GET_SET = (function() {
+      if (!('defineProperties' in Object)) return false;
+      try {
+        var obj = {};
+        Object.defineProperties(obj, { prop: { 'get': function () { return true; } } });
+        return obj.prop;
+      } catch (_) {
+        return false;
+      }
+    })();
 
     var self = ES5_GET_SET ? this : document.createElement('a');
 


### PR DESCRIPTION
If someone loads this polyfill in a page which already has a defineProperty polyfill, trying to set an accessor property using defineProperty might throw an exception.