### PR TITLE
Avoid crashing on PhantomJS (keyboard polyfill)

### DIFF
--- a/keyboard.js
+++ b/keyboard.js
@@ -603,7 +603,7 @@
 
   var codeTable = remap(keyCodeToInfoTable, 'code');
 
-  var nativeLocation = 'KeyboardEvent' in global && 'location' in new KeyboardEvent('');
+  var nativeLocation = 'KeyboardEvent' in global && typeof KeyboardEvent === 'function' && 'location' in new KeyboardEvent('');
 
   function keyInfoForEvent(event) {
     var keyCode = 'keyCode' in event ? event.keyCode : 'which' in event ? event.which : 0;


### PR DESCRIPTION
PhantomJS's implementation of keyboard events seem to be funky, as KeyboardEvent is not a constructor.

Just adding an extra check seems to fix things up.