### PR TITLE
assign origURL[i] to URL instead of itself

### DIFF
--- a/tests/url_tests.js
+++ b/tests/url_tests.js
@@ -301,6 +301,11 @@ test('URLSearchParams iterable methods', function () {
   }
 });
 
+test('URL contains native static methods', function () {
+    ok(typeof URL.createObjectURL == 'function');
+    ok(typeof URL.revokeObjectURL == 'function');
+});
+
 test('Regression tests', function() {
   // IE mangles the pathname when assigning to search with 'about:' URLs
   var p = new URL('about:blank').searchParams;

--- a/url.js
+++ b/url.js
@@ -415,7 +415,7 @@
   if (origURL) {
     for (var i in origURL) {
       if (origURL.hasOwnProperty(i) && typeof origURL[i] === 'function')
-        global.URL[i] = origURL[i];
+        URL[i] = origURL[i];
     }
   }
 


### PR DESCRIPTION
On line 418, `global.URL` and `origURL` are the same object. This means that right now, `URL.createObjectURL` and `URL.revokeObjectURL` are both `undefined` after including this polyfill. We want to add the properties to `URL`, not `global.URL`.