### PR TITLE
Added elem.matches() aliases and polyfill 

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ DOM
 * [Selectors](https://dom.spec.whatwg.org/#scope-match-a-selectors-string) (for IE7-) - adapted from [Paul Young](http://ajaxian.com/archives/creating-a-queryselector-for-ie-that-runs-at-native-speed)
   * `element = document.querySelector(selector)`
   * `elementArray = document.querySelectorAll(selector)`
+* `elem.matches(stringSelector)` (for IE, Firefox 3.6, early Webkit and Opera 15.0)
 * `elementArray = document.getElementsByClassName(classNames)` (for IE8-)
 * `e = element.nextElementSibling`, `e = element.previousElementSibling` (for IE8)
 * Node constants: `Node.ELEMENT_NODE`, etc (for IE8-)

--- a/dom.js
+++ b/dom.js
@@ -435,4 +435,31 @@
       });
     }
   }());
+
+  // Element.matches
+  // https://developer.mozilla.org/en/docs/Web/API/Element/matches
+  // Needed for: IE, Firefox 3.6, early Webkit and Opera 15.0
+  // Use msMatchesSelector(selectorString) for IE
+  // Use oMatchesSelector(selectorString) for Opera 15.0
+  // Use mozMatchesSelector(selectorString) for Firefox 3.6
+  // Use webkitMatchesSelector(selectorString) for early Webkit
+  // Use polyfill if no matches() support, but querySelectorAll() support
+  if (!Element.prototype.matches) {
+    if (Element.prototype.msMatchesSelector) {
+      Element.prototype.matches = Element.prototype.msMatchesSelector;
+    } else if (Element.prototype.oMatchesSelector) {
+      Element.prototype.matches = Element.prototype.oMatchesSelector;
+    } else if (Element.prototype.mozMatchesSelector) {
+      Element.prototype.matches = Element.prototype.mozMatchesSelector;
+    } else if (Element.prototype.webkitMatchesSelector) {
+      Element.prototype.matches = Element.prototype.webkitMatchesSelector;
+    } else if (document.querySelectorAll) {
+      Element.prototype.matches = function matchesQueryAllPolyfill(selectorString) {
+        var matches = (this.document || this.ownerDocument).querySelectorAll(selectorString),
+        i = matches.length;
+        while (--i >= 0 && matches.item(i) !== this) {}
+        return i > -1;
+      };
+    }
+  }
 }(self));

--- a/tests/dom_tests.js
+++ b/tests/dom_tests.js
@@ -153,3 +153,8 @@ test('next/previousElementSibling', function() {
   assertTrue("document.querySelector('#two').nextElementSibling === document.querySelector('#three')");
   assertTrue("document.querySelector('#three').nextElementSibling === null");
 });
+
+test("matches", function() {
+  assertTrue("document.querySelector('#foo').matches('.alpha')");
+  assertTrue("document.querySelector('#baz').matches('.beta')");
+});


### PR DESCRIPTION
elem.matches() for IE, Firefox 3.6, early Webkit and Opera 15.0, and any others that have querySelectorAll(), but not matches().
https://developer.mozilla.org/en/docs/Web/API/Element/matches

Added tests and simple line to documentation