### PR TITLE
Ensure params are copied by value when cloning an URLSearchParams object

### DIFF
--- a/tests/url_tests.js
+++ b/tests/url_tests.js
@@ -270,6 +270,16 @@ test('URLSearchParams mutation', function () {
   sp2.append('c', '3');
   equal(String(sp1), 'a=1&b=2');
   equal(String(sp2), 'a=1&c=3');
+
+  var sp3 = new URLSearchParams('a=1');
+  equal(String(sp3), 'a=1');
+  var sp4 = new URLSearchParams(sp3);
+  equal(String(sp4), 'a=1');
+  sp4.set('a', 2);
+  equal(sp3.get('a'), 1);
+  equal(String(sp3), 'a=1');
+  equal(sp4.get('a'), 2);
+  equal(String(sp4), 'a=2');
 });
 
 test('URLSearchParams serialization', function() {

--- a/url.js
+++ b/url.js
@@ -84,16 +84,15 @@
     if (init === undefined || init === null)
       init = '';
 
-    if (Object(init) !== init || !(init instanceof URLSearchParams))
+    if (Object(init) !== init || (init instanceof URLSearchParams))
       init = String(init);
 
-    if (typeof init === 'string' && init.substring(0, 1) === '?')
-      init = init.substring(1);
-
-    if (typeof init === 'string')
+    if (typeof init === 'string') {
+      if (init.substring(0, 1) === '?') {
+        init = init.substring(1);
+      }
       this._list = urlencoded_parse(init);
-    else
-      this._list = init._list.slice();
+    }
 
     this._url_object = null;
     this._setList = function (list) { if (!updating) $this._list = list; };


### PR DESCRIPTION
At the moment, when an `URLSearchParams` object is instantiated by passing an existing `URLSearchParams` object to the constructor, the search parameters contained in the list are copied by reference.

This PR aims to fix this issue by converting the argument to a string and let the original code rebuilt the search parameters list.