### PR TITLE
Remove 7.4.9 & 7.4.9.1 comments as those sections do not exist

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -581,8 +581,6 @@
 
   // 7.4.8 CreateListIterator (list)
   // 7.4.8.1 ListIterator next( )
-  // 7.4.9 CreateCompoundIterator ( iterator1, iterator2 )
-  // 7.4.9.1 CompoundIterator next( )
 
   //----------------------------------------
   // 8 Executable Code and Execution Contexts


### PR DESCRIPTION
[Section 7.4 Operations on Iterator Objects](https://tc39.github.io/ecma262/#sec-operations-on-iterator-objects) goes to 7.4.8.1, there is no 7.4.9 section.