### PR TITLE
Detect URL implementations that don't support search setter

### DIFF
--- a/url.js
+++ b/url.js
@@ -32,10 +32,20 @@
     try {
       if (origURL) {
         nativeURL = new global.URL('http://example.com');
-        if ('searchParams' in nativeURL)
-          return;
-        if (!('href' in nativeURL))
-          nativeURL = undefined;
+        if ('searchParams' in nativeURL) {
+					var url = new URL('http://example.com');
+					url.search = 'a=1&b=2';
+					if (url.href === 'http://example.com/?a=1&b=2') {
+						url.search = '';
+						if (url.href === 'http://example.com/') {
+							return;
+						}
+					}
+				}
+        if (!('href' in nativeURL)) {
+					nativeURL = undefined;
+				}
+				nativeURL = undefined;
       }
     } catch (_) {}
 

--- a/url.js
+++ b/url.js
@@ -33,19 +33,19 @@
       if (origURL) {
         nativeURL = new global.URL('http://example.com');
         if ('searchParams' in nativeURL) {
-					var url = new URL('http://example.com');
-					url.search = 'a=1&b=2';
-					if (url.href === 'http://example.com/?a=1&b=2') {
-						url.search = '';
-						if (url.href === 'http://example.com/') {
-							return;
-						}
-					}
-				}
+          var url = new URL('http://example.com');
+          url.search = 'a=1&b=2';
+          if (url.href === 'http://example.com/?a=1&b=2') {
+            url.search = '';
+            if (url.href === 'http://example.com/') {
+              return;
+            }
+          }
+        }
         if (!('href' in nativeURL)) {
-					nativeURL = undefined;
-				}
-				nativeURL = undefined;
+          nativeURL = undefined;
+        }
+        nativeURL = undefined;
       }
     } catch (_) {}
 


### PR DESCRIPTION
It looks like Safari 10.1 has an issue with the URL search setter. I've patched the feature detection in the polyfill to ensure that the polyfill is applied if URL implementations have a buggy search setter.
Here is a screenshot of the tests running on Safari 10.1:
![Screenshot of Safari 10.1 running the url tests and having a test failure](https://user-images.githubusercontent.com/1569131/34644899-02299c50-f338-11e7-8e8d-b992c70ad1d2.jpg)

Here is a screenshot of the tests running on Safari 10.1 after the feature detect was patched:
![Screenshot of Safari 10.1 running the url test and having all the tests passing](https://user-images.githubusercontent.com/1569131/34644900-18656742-f338-11e7-8651-33489da4a230.jpg)

