### PR TITLE
Fix CustomEvent Implementation

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -222,15 +222,18 @@
   // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent
   // Needed for: IE
   (function () {
-    if ('CustomEvent' in global && typeof global.CustomEvent === "function")
+    if (typeof global.CustomEvent === "function")
       return;
     function CustomEvent ( event, params ) {
       params = params || { bubbles: false, cancelable: false, detail: undefined };
-      var evt = document.createEvent( 'CustomEvent' );
+      var evt = createCustomEvent();
       evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );
       return evt;
     }
-    CustomEvent.prototype = global.Event.prototype;
+    function createCustomEvent() {
+      return document.createEvent( 'CustomEvent' );
+    }
+    CustomEvent.prototype = createCustomEvent().constructor.prototype;
     global.CustomEvent = CustomEvent;
   })();
 


### PR DESCRIPTION
Currently `new CustomEvent('!').constructor === CustomEvent` returns `false` in IE11, which is a hell of a bummer for anything else that is either polyfilling or feature detecting CustomEvent after this file is on the page.

Bonus: I have removed the redundant `in` check when `typeof` is all it's needed.

Please consider publishing this fix ASAP since it's conflicting with other polyfills.

Thank you.