### PR TITLE
Fix isName regular expression

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -69,7 +69,7 @@
   }
 
   function isName(s) {
-    return /^[!#$%&'*+\-.09A-Z^_`a-z|~]+$/.test(s);
+    return /^[!#$%&'*+\-.0-9A-Z^_`a-z|~]+$/.test(s);
   }
   function isValue(s) {
     // TODO: Implement me

--- a/polyfill.js
+++ b/polyfill.js
@@ -6089,7 +6089,7 @@ function __cons(t, a) {
   }
 
   function isName(s) {
-    return /^[!#$%&'*+\-.09A-Z^_`a-z|~]+$/.test(s);
+    return /^[!#$%&'*+\-.0-9A-Z^_`a-z|~]+$/.test(s);
   }
   function isValue(s) {
     // TODO: Implement me

--- a/web.js
+++ b/web.js
@@ -1490,7 +1490,7 @@
   }
 
   function isName(s) {
-    return /^[!#$%&'*+\-.09A-Z^_`a-z|~]+$/.test(s);
+    return /^[!#$%&'*+\-.0-9A-Z^_`a-z|~]+$/.test(s);
   }
   function isValue(s) {
     // TODO: Implement me


### PR DESCRIPTION
Regular expression for header name was wrong, that caused headers like "P3P" to fail, because `3` was not in the set of accepted chars.

According to https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
the field name is defined as `field name = token`, the token is defined as `token = 1*tchar`, where tchar is 
```
tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." /"^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
```
`ALPHA` is defined in https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1 as
```
ALPHA          =  %x41-5A / %x61-7A   ; A-Z / a-z
```
and `DIGIT` is defined as
```
DIGIT          =  %x30-39 ; 0-9
```

`isName` regular expression was ``/^[!#$%&'*+\-.09A-Z^_`a-z|~]+$/`` and with all above info the issue is easily spotted, because `0`, and `9` should have `-` between them, and the regular expression should look like ``/^[!#$%&'*+\-.0-9A-Z^_`a-z|~]+$/``.